### PR TITLE
Mention flex output needs explicit output option defined

### DIFF
--- a/_manual/06-flex-output.md
+++ b/_manual/06-flex-output.md
@@ -16,7 +16,8 @@ and how. It is configured through a Lua file which
 * defines the structure of the output tables and
 * defines functions to map the OSM data to the database data format
 
-Use the `-s, --style=FILE` option to specify the name of the Lua file.
+Use the `-s, --style=FILE` option to specify the name of the Lua file
+along with the `-O, --output=flex` option to specify the use of the flex output.
 
 Unlike the pgsql output, the flex output doesn't use command line options
 for configuration, but the Lua config file only.


### PR DESCRIPTION
This change makes it clear the output option needs to be defined in order to use the flex output.  It probably should have been obvious to me but I missed that detail during my initial testing.  Luckily I had another user related error and was pointed in the right direction (https://github.com/openstreetmap/osm2pgsql/issues/1348).

Attempting to run with a flex style defined but the pgsql output results in this message from osm2pgsql:

```
2020-12-01 07:51:21  WARNING: Unknown flag 'a' line 2, ignored
2020-12-01 07:51:21  node cache: stored: 0(0.00%), storage efficiency: 0.00% (dense blocks: 0, sparse nodes: 0), hit rate: 0.00%
2020-12-01 07:51:21  ERROR: Weird style line /path/to/osm2pgsql/flex-config/simple.lua:2.
```