### PR TITLE
add `attributionsCollapsible: false` to the vector-tiles example

### DIFF
--- a/examples/vector-tiles/index.md
+++ b/examples/vector-tiles/index.md
@@ -110,6 +110,7 @@ var layer =
         declutter: true,
         source: new ol.source.VectorTile({
             attributions: ol.source.OSM.ATTRIBUTION,
+            attributionsCollapsible: false,
             format: new ol.format.MVT(),
             url: 'tiles/{z}/{x}/{y}.pbf',
         }),


### PR DESCRIPTION
imho:  OpenStreetMap Attribution should be not collapsible in the [vector-tiles example](https://osm2pgsql.org/examples/vector-tiles/) 


before:
![image](https://user-images.githubusercontent.com/2217320/100965732-9e432b00-352b-11eb-8032-885270fbe792.png)


after:

![image](https://user-images.githubusercontent.com/2217320/100965764-b2872800-352b-11eb-985d-f13ccc0f18a3.png)
