### PR TITLE
fix local run - missing contact.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ To run it locally, you need Ruby. Then check out the repository and install
 Jekyll:
 
 ```
-git checkout https://github.com/openstreetmap/osm2pgsql-website
+git clone https://github.com/openstreetmap/osm2pgsql-website
 cd osm2pgsql-website
 gem install bundler jekyll
+touch contact.md
 bundle exec jekyll serve
 ```
 


### PR DESCRIPTION
this is my quick fix ...

Problem:
* without `contact.md` ( included in the `.gitignore`)    the command:  `bundle exec jekyll serve` crash ... 
* a simple `touch contact.md` fix it.


error message : 
```bash
  Liquid Exception: Could not find document 'contact.md' in tag 'link'. Make sure the document exists and the path is correct. in /_layouts/default.html
jekyll 3.8.7 | Error:  Could not find document 'contact.md' in tag 'link'.
...
/var/lib/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/tags/link.rb:27:in `render': Could not find document 'contact.md' in tag 'link'. (ArgumentError)

```