### PR TITLE
Update Postgres configuration recommendations

### DIFF
--- a/_manual/03-database.md
+++ b/_manual/03-database.md
@@ -97,8 +97,7 @@ The value in the third column is the default set by PostgreSQL 13.
 
 | Config Option                | Proposed Value  | Pg 13 Default Value | Remark |
 | ---------------------------- | ------ | ------ | --- |
-| shared_buffers               | 10GB    | 128MB | Leaves plenty of RAM for Pg work_mems and osm2pgsql cache |
-| effective_cache_size         | 24GB   | 4GB | |
+| shared_buffers               | 1GB    | 128MB | Lower than typical Postgres recommendations to give osm2pgsql priority to RAM. |
 | maintenance_work_mem         | 10GB   | 64MB | Improves `CREATE INDEX` |
 | autovacuum_work_mem          | 2GB    | -1 | -1 uses `maintenance_work_mem` |
 | work_mem                     | 50MB   | 4MB | |
@@ -131,13 +130,11 @@ in the PostgreSQL documentation.
 
 The suggestions in this section are *potentially dangerous* and
 are not suitable for all environments.
-These settings can cause crashes, data loss and/or corruption.  Corruption in a Postgres
+These settings can cause crashes and/or corruption.  Corruption in a Postgres
 instance can lead to a "bricked" instance affecting all databases in the instance.
 
 | Config Option                | Proposed Value  | Pg 13 Default Value | Remark |
 | ---------------------------- | ------ | ------ | --- |
-| work_mem                     | 200MB  | 4MB | Systems with multiple users and complex queries could exhaust available RAM. |
-| synchronous_commit           | off    | on | Warning: Risks data loss.  Set back to `on` after import. |
 | full_page_writes             | off    | on |  Warning: Risks data corruption.  Set back to `on` after import. |
 | fsync                        | off    | on |  Warning: Risks data corruption.  Set back to `on` after import. |
 {: .desc}

--- a/_manual/03-database.md
+++ b/_manual/03-database.md
@@ -86,31 +86,33 @@ creating the database for osm2pgsql with `createdb`.
 ### Tuning the PostgreSQL Server
 
 Usual installs of the PostgreSQL server come with a default configuration
-that isn't well tuned for large databases. You **will** have to change those
-settings and restart PostgreSQL before running osm2pgsql, otherwise your system
+that isn't well tuned for large databases. You should change these
+settings in `postgresql.conf` and restart PostgreSQL before running osm2pgsql, otherwise your system
 will be much slower than necessary.
 
-You should tune the following parameters in your `postgresql.conf` file. The
+The
 values in the second column are suggestions and good starting point for a
 typical setup, you might have to adjust them for your use case. The settings
-are somewhat geared towards a system with 64GB RAM and a fast SSD.
+are geared towards a system with 64GB RAM and a fast SSD. The
+Default Value in the third column is the default for PostgreSQL 13.
 
-| Config Option                | Proposed Value  | Remark |
-| ---------------------------- | ------ | --- |
-| shared_buffers               | 2GB    | |
-| maintenance_work_mem         | 10GB   | |
-| autovacuum_work_mem          | 2GB    | |
-| work_mem                     | 50MB   | |
-| effective_cache_size         | 24GB   | |
-| synchronous_commit           | off    | |
-| checkpoint_segments          | 100    | PostgreSQL <= 9.4 only |
-| max_wal_size                 | 1GB    | PostgreSQL > 9.4 only |
-| checkpoint_timeout           | 10min  | |
-| checkpoint_completion_target | 0.9    | |
+| Config Option                | Proposed Value  | Pg 13 Default Value | Remark |
+| ---------------------------- | ------ | ------ | --- |
+| shared_buffers               | 10GB    | 128MB | Leaves plenty of RAM for Pg work_mems and osm2pgsql cache |
+| effective_cache_size         | 24GB   | 4GB | |
+| maintenance_work_mem         | 10GB   | 64MB | Improves `CREATE INDEX` |
+| autovacuum_work_mem          | 2GB    | -1 | -1 uses `maintenance_work_mem` |
+| work_mem                     | 50MB   | 4MB | |
+| max_wal_size                 | 10GB    |1GB | PostgreSQL > 9.4 only.  For PostgreSQL <= 9.4 set checkpoint_segments = 100 or higher. |
+| checkpoint_timeout           | 60min  | 5min | Increasing this value increases time to restore from PITR |
+| checkpoint_completion_target | 0.9    | 0.5 | Spreads out checkpoint I/O reducing spikes of disk activity |
+| random_page_cost | 4 | 2 | Assuming fast SSDs |
 {: .desc}
 
-A higher number for `max_wal_size` means that PostgreSQL needs to run
+A higher value for `max_wal_size` and `checkpoint_timeout` means that PostgreSQL needs to run
 checkpoints less often but it does require the additional space on your disk.
+In comparison to the size of the PBF and data in PostGIS this is typically a
+non-issue.
 
 Autovacuum must not be switched off because it ensures that the tables are
 frequently analysed. If your machine has very little memory, you might consider
@@ -118,19 +120,28 @@ setting `autovacuum_max_workers = 1` and reduce `autovacuum_work_mem` even
 further. This will reduce the amount of memory that autovacuum takes away from
 the import process.
 
-For the initial import, you should also set:
+### Expert tuning
 
-```
-fsync = off
-full_page_writes = off
-```
+The suggestions in this section are considered "Expert" options and
+are not suitable for all environments.
+Some of these settings can cause crashes, data loss and/or corruption.  Corruption can lead to a "bricked" instance affecting all
+databases in the instance.
 
-Don't forget to reenable them after the initial import or you risk database
-corruption!
+
+| Config Option                | Proposed Value  | Pg 13 Default Value | Remark |
+| ---------------------------- | ------ | ------ | --- |
+| wal_level					   | minimal | replica | Reduces WAL activity if replication is not required during data load.  Must set `max_wal_senders=0` |
+| max_wal_senders | 0 | 10 | See `wal_level` |
+| work_mem                     | 200MB  | 4MB | Systems with multiple users and complex queries could exhaust available RAM. |
+| synchronous_commit           | off    | on | Warning: Risks data loss.  Reset after import. |
+| full_page_writes             | off    | on |  Warning: Risks data corruption.  Set back to on after import. |
+| fsync                        | off    | on |  Warning: Risks data corruption.  Set back to on after import. |
+{: .desc}
+
 
 For details see also the [Resource Consumption section in the Server
 Configuration chapter](https://www.postgresql.org/docs/current/runtime-config-resource.html){:.extlink}
 in the PostgreSQL documentation. Some information is also on the PostgreSQL
 wiki: [Tuning Your PostgreSQL
 Server](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server){:.extlink}.
-
+The section titled `synchronous_commit` contains important information to the `synchronous_commit` and `fsync` settings.


### PR DESCRIPTION
This PR updates the recommended `postgresql.conf` configuration changes to reflect best practices with modern Postgres. Most of the configuration recommendations are the same, though some were updated and others are completely new.  The only row item removed was `checkpoint_segments`, I put notes about that in the remarks of `max_wal_size` since Pg9.4 has been EOL almost a year now.  I assume anyone running EOL Pg has been running it long enough they probably know those options.

The recommended changes are now split into two sections.  I put the common and safe changes in one section and potentially dangerous changes under a new "Expert tuning" section.  This makes it clear there are potentially serious side effects to making those changes while still providing guidance to the power users with more extreme needs.

The tables now have a column showing the Postgres 13 default values along with the recommended values. I considered adding links to the [postgresql.conf comparison site](https://pgconfig.rustprooflabs.com/param/shared_buffers) to show the history of each option back through Pg9.2.  I was not sure if that would be helpful to users, or just look spammy.
 