### PR TITLE
Remove pgBouncer suggestion

### DIFF
--- a/_manual/03-database.md
+++ b/_manual/03-database.md
@@ -177,9 +177,15 @@ update. But this might change from version to version of osm2pgsql.)
 
 If you are hit by this, your options are to
 
-* increase the `max_connections` settings in your database configuration,
+* increase the `max_connections` settings in your database configuration, or
 * reduce the number of threads with the `--number-processes=THREADS` command
-  line option of osm2pgsql, or
-* use [pgBouncer](https://www.pgbouncer.org/) to reduce the number of
-  connections your server sees.
+  line option of osm2pgsql.
+
+Using a connection pool, such as pgBouncer, is not an option to reduce the number
+of osm2pgsql connections. This is due to osm2pgsql opening and holding `idle` connections
+for the duration of the processing. This behavior prevents pgBouncer's `session` based
+pooling from providing any benefit in reducing the number of connections seen by PostgreSQL.
+The use of prepared statements in osm2pgsql prevents other pooling methods (e.g. `transaction`)
+from functioning.
+
 


### PR DESCRIPTION
This removes the suggestion to use pgBouncer as an option to mitigate large number of connections to Postgres, and adds an explanation why pgBouncer cannot be used. 

[The comment on this discussion](https://github.com/openstreetmap/osm2pgsql/discussions/1650#discussioncomment-2570706) shows how osm2pgsql opens connections and holds them idle for the duration of osm2pgsql processing.  This behavior makes the `session` transaction pool method useless, since osm2pgsql won't let go of the connections until it completes processing. With this behavior, the pool must accept the entire volume of osm2pgsql connections, gaining nothing over simply raising Postgres' `max_connections` value.

The use of prepared statements makes [transaction pooling](https://www.pgbouncer.org/faq.html#how-to-use-prepared-statements-with-transaction-pooling) a non-viable solution, leaving no possible way pgBouncer helps.

 

