### PR TITLE
Fix example for style testing

### DIFF
--- a/_manual-v2/13-style-testing.md
+++ b/_manual-v2/13-style-testing.md
@@ -58,15 +58,16 @@ Scenario: An OSM tree node will be imported
         """
         local trees = osm2pgsql.define_node_table('trees', {
             { column = 'name', type = 'text' },
-            { column = 'geom', type = 'point', srid=4326 })
+            { column = 'geom', type = 'point', srid = 4326 }
+        })
 
         function osm2pgsql.process_node(object)
-          if object.tags.natural == 'tree' then
-            trees:insert{
-              name = tags.name,
-              geom = geom:as_point()
-            }
-          end
+            if object.tags.natural == 'tree' then
+                trees:insert {
+                    name = object.tags.name,
+                    geom = object:as_point()
+                }
+            end
         end
         """
     When running osm2pgsql flex


### PR DESCRIPTION
When I tried the basic example of the stlye tester script it failed with internal errors.

So I ran the flex style on a fresh database and also discovered the same internal errors.

My conclusion is that the example Lua code is malformed. This PR tries to fix it.

- the first variable was missing closing brackets
- the function referenced a variable that did not exist

